### PR TITLE
Catalog-info.yaml validation script

### DIFF
--- a/.github/workflows/validate_catalog.yaml
+++ b/.github/workflows/validate_catalog.yaml
@@ -1,0 +1,21 @@
+# Validate catalog-info.yaml file
+name: Validate Catalog-info.yaml
+on:
+  pull_request:
+    paths:
+      - 'catalog-info.yaml'
+  push:
+    paths:
+      - 'catalog-info.yaml'
+    branches: [ main ]
+
+jobs:
+  validate_catalog:
+    runs-on: [ubuntu-latest]
+    steps:
+      - id: 'Checkout'
+        uses: actions/checkout@v2
+
+      - id: 'Validate'
+        uses: 'RoadieHQ/backstage-entity-validator@v0.3.2'
+  


### PR DESCRIPTION
### WHAT
You are receiving this PR because your repository is cataloged by unity-backstage through your catalog-info.yaml file that is located at the root level. We are adding a validation script to your workflows to ensure it is automatically validated every time you change that file.

### WHY
While our current setup for backstage validation does catch errors and reports to our error validation slack channel, unity-backstage usage is growing and as a result managing errors is becoming more intricate and inefficient. This is why we are making the validation happen at the repository level.

For more information, please see [unity-backstage](https://docs.unityops.net/unity-backstage/)

### RUNNER LABEL
The runner is selected to be ubuntu-latest because the runner group does not automatically get added to repos under github, and since there is no need to run on self-hosted runners we decided to use ubuntu-latest. If you already have a runner attached to your repo, feel free to change the label from ```ubuntu-latest``` to ```unity-linux-runner```, if you would like to attach unity hosted runners please submit a [PR here](https://github.com/Unity-Technologies/github-actions-runners/blob/main/unity-runners.yaml)

[_Created by Sourcegraph batch change `omar.moharrem/backstage-catalog-validator`._](https://sourcegraph.ds.unity3d.com/users/omar.moharrem/batch-changes/backstage-catalog-validator)